### PR TITLE
Scores to floats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.settings/
 /.classpath
 /.project
+/old_build.rar

--- a/src/main/java/nl/uva/larissa/json/model/Score.java
+++ b/src/main/java/nl/uva/larissa/json/model/Score.java
@@ -5,9 +5,9 @@ package nl.uva.larissa.json.model;
 // also SCORM 2004 4th edition says something about 7 digits and claims raw is superseded but defines it anyway!
 public class Score {
 	Float scaled;
-	Integer raw;
-	Integer min;
-	Integer max;
+	Float raw;
+	Float min;
+	Float max;
 
 	public Float getScaled() {
 		return scaled;
@@ -17,27 +17,27 @@ public class Score {
 		this.scaled = scaled;
 	}
 
-	public Integer getRaw() {
+	public Float getRaw() {
 		return raw;
 	}
 
-	public void setRaw(Integer raw) {
+	public void setRaw(Float raw) {
 		this.raw = raw;
 	}
 
-	public Integer getMin() {
+	public Float getMin() {
 		return min;
 	}
 
-	public void setMin(Integer min) {
+	public void setMin(Float min) {
 		this.min = min;
 	}
 
-	public Integer getMax() {
+	public Float getMax() {
 		return max;
 	}
 
-	public void setMax(Integer max) {
+	public void setMax(Float max) {
 		this.max = max;
 	}
 

--- a/src/test/resources/testStatementWithResult2.json
+++ b/src/test/resources/testStatementWithResult2.json
@@ -18,9 +18,9 @@
   "result" : {
     "score" : {
       "scaled" : 0.2,
-      "raw" : 20,
-      "min" : 0,
-      "max" : 100
+      "raw" : 20.6,
+      "min" : 0.0,
+      "max" : 100.0
     },
     "success" : false
   },

--- a/src/test/resources/testStatementWithScore1.json
+++ b/src/test/resources/testStatementWithScore1.json
@@ -26,8 +26,8 @@
   },
   "result" : {
     "score" : {
-      "raw" : 679,
-      "min" : 0
+      "raw" : 679.1,
+      "min" : 0.0
     },
     "extensions" : {
       "http://tincanapi.com/JsTetris_TCAPI/time" : "11",


### PR DESCRIPTION
Spec v1.0.1 says "result/score/(raw|max|min)" should be a decimal number, which in any case does not mean an integer.